### PR TITLE
Broken link fixed in the demo and tutorials section of the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To see how traning is done run the following command:
 $ python tests/integration_tests/integration_test.py --config configs/regression.yml
 ```
 # Demos and Tutorials
-You may find all the EnvisEdge related demos and tutorials [here](https://github.com/NimbleEdge/EnvisEdge/tree/refactor-user-module/docs).
+You may find all the EnvisEdge related demos and tutorials [here](https://github.com/NimbleEdge/EnvisEdge/tree/main/docs/source/tutorials).
 
 You may also find the official documentation [here](https://docs.nimbleedge.ai/).
 


### PR DESCRIPTION
## Description
I successfully fixed the broken link in the README file under the demos and tutorials section in the first paragraph. Initially the link to the tutorials folder was directing to the wrong path which I correctly. 
This is the tag to the Pull Request **#213**
 

## Affected Dependencies
None.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/NimbleEdge/EnvisEdge/labels)
- [x] My changes are covered by tests
