### PR TITLE
fixed links in tutorial-6 documentation

### DIFF
--- a/docs/source/tutorials/Tutorial-Part-6-customization.rst
+++ b/docs/source/tutorials/Tutorial-Part-6-customization.rst
@@ -11,7 +11,7 @@ Good for non-persistent and dynamic settings like gpu device
 
 *In case of conflict, CLI argument supercedes config file parameter.*
 For further reference, check out `training config
-flags <configs/flags.md>`__
+flags <../../flags.md>`__
 
 Model Architecture
 ------------------
@@ -53,7 +53,7 @@ into registry.
            ... 
 
 You can define your own modules and add them in the
-`fedrec/modules <fedrec/modules>`__. Finally set the ``name`` flag of
+`fedrec/modules <../fedrec/fedrec.modules.rst>`__. Finally set the ``name`` flag of
 ``model`` tag in config file
 
 .. code::


### PR DESCRIPTION
## Description
Fixed a couple of broken links in the `tutorial-6-customization` documentation. 

## Relevant Issue
#217 

## Affected Dependencies
None

## How has this been tested?
None

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/NimbleEdge/EnvisEdge/labels)
- [ ] My changes are covered by tests
