### PR TITLE
documentation 📃 : Fix typo in tutorial part 4 deployment.rst

### DIFF
--- a/docs/source/tutorials/Tutorial-Part-4-deployment.rst
+++ b/docs/source/tutorials/Tutorial-Part-4-deployment.rst
@@ -134,7 +134,7 @@ Hosting the models
 ~~~~~~~~~~~~~~~~~~
 
 Finally, we host all the plans and global model weights and make them
-avaialble to beb downloaded by the workers.
+available to be downloaded by the workers.
 
 .. code:: python
 


### PR DESCRIPTION
## Description
Fixed typo in Tutorial Part 4 deployment.rst. 
Changed "avaialble to be" to "available to be" 
Under "Hosting the models" subheading
https://docs.nimbleedge.ai/tutorials/tutorial-part-4-deployment#hosting-the-models

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/NimbleEdge/EnvisEdge/labels)
- [x] My changes are covered by tests
