### PR TITLE
added inline documentation and edited some codes

### DIFF
--- a/fedrec/utilities/cuda_utils.py
+++ b/fedrec/utilities/cuda_utils.py
@@ -1,7 +1,24 @@
+#------------------------------------------------
+""" 
+importing necessary (libraries) 
+torch ---> PyTorch is a Python package that provides two high-level features:
+Tensor computation (like NumPy) with strong GPU acceleration
+Deep neural networks built on a tape-based autograd system
+
+socket ---> Python package which allows creation of simple servers and clients for communication with sockets. Supports both Python2 and Python3.
+logging ---> This module is intended to provide a standard error logging mechanism in Python as per PEP 282.
+
+"""
 import torch
 import socket
 import logging
-
+"""
+function name ---> map_to_cuda 
+if the input to the function is of type "List" or "Tuple" it will return [map_to_cuda(arg, device, **kwargs) for arg in args]
+if the input to the function is of type "Dictionary" it will return {k: map_to_cuda(v, device, **kwargs) for k, v in args.items()}
+if the input to the function is of type "torch.Tensor" it will return args.cuda(device, **kwargs)
+if there is unmatched of all it will raise TypeError "unsupported type for cuda migration"
+"""
 
 def map_to_cuda(args, device=None, **kwargs):
     if isinstance(args, (list, tuple)):
@@ -13,13 +30,29 @@ def map_to_cuda(args, device=None, **kwargs):
     else:
         raise TypeError("unsupported type for cuda migration")
 
-
+"""
+function name--> map_to_list
+input--> model_params
+It will convert the input (model_params) to list and return it
+"""
 def map_to_list(model_params):
     for k in model_params.keys():
-        model_params[k] = model_params[k].detach().numpy().tolist()
+        model_params[k] = model_params[k].detach().cpu().numpy().tolist()
     return model_params
 
-
+"""
+function name--> mapping_processes_to_gpus
+inputs--> gpu_config, process_id, worker_number
+if the gpu_config (input) is None then the device will be cpu and it will return the device
+else it will return the total description of GPUs present 
+informations it will print---->
+        logging.info("Process: %d" % (process_id))
+        logging.info("host: %s" % (gpu_util_map[process_id][0]))  
+        logging.info("gethostname: %s" % (socket.gethostname()))  
+        logging.info("gpu: %d" % (gpu_util_map[process_id][1]))
+        
+Now as GPU or GPUs are present it will be returned as device with their logging info 
+"""
 def mapping_processes_to_gpus(gpu_config, process_id, worker_number):
     if gpu_config == None:
         device = torch.device("cpu")


### PR DESCRIPTION
1.Inline Documentation 
2. added .cpu() 
why?? reason- The reason for requiring explicit .cpu() is that CPU tensors and the converted numpy arrays share memory. If a .cpu() is implicitly done, the operation will be different for CUDA and CPU tensors, and we wanted to be explicit to avoid bugs.
Reference- https://discuss.pytorch.org/t/should-it-really-be-necessary-to-do-var-detach-cpu-numpy/35489/5

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Relevant Issue
Issue #Tag the issue here

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/NimbleEdge/EnvisEdge/labels)
- [ ] My changes are covered by tests
