### PR TITLE
Add scalafmt.conf and format all existing scala code

### DIFF
--- a/scala_core/.scalafmt.conf
+++ b/scala_core/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = "3.5.7"
+runner.dialect = "scala213"
+maxColumn = 120

--- a/scala_core/project/plugins.sbt
+++ b/scala_core/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/Aggregator.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/Aggregator.scala
@@ -13,157 +13,213 @@ import akka.actor.typed.Signal
 import akka.actor.typed.PostStop
 
 object Aggregator {
-    def apply(aggId: AggregatorIdentifier): Behavior[Command] =
-        Behaviors.setup(new Aggregator(_, aggId))
-    
-    trait Command
+  def apply(aggId: AggregatorIdentifier): Behavior[Command] =
+    Behaviors.setup(new Aggregator(_, aggId))
 
-    // In case of any Trainer / Aggregator (Child) Termination
-    private final case class AggregatorTerminated(actor: ActorRef[Aggregator.Command], aggId: AggregatorIdentifier)
-        extends Aggregator.Command
-    
-    private final case class TrainerTerminated(actor: ActorRef[Trainer.Command], traId: TrainerIdentifier)
-        extends Aggregator.Command
+  trait Command
 
-    // TODO
-    // Add messages here
+  // In case of any Trainer / Aggregator (Child) Termination
+  private final case class AggregatorTerminated(
+      actor: ActorRef[Aggregator.Command],
+      aggId: AggregatorIdentifier
+  ) extends Aggregator.Command
+
+  private final case class TrainerTerminated(
+      actor: ActorRef[Trainer.Command],
+      traId: TrainerIdentifier
+  ) extends Aggregator.Command
+
+  // TODO
+  // Add messages here
 }
 
-class Aggregator(context: ActorContext[Aggregator.Command], aggId: AggregatorIdentifier) extends AbstractBehavior[Aggregator.Command](context) {
-    import Aggregator._
-    import FLSystemManager.{ RequestTrainer, TrainerRegistered, RequestAggregator, AggregatorRegistered, RequestRealTimeGraph }
+class Aggregator(
+    context: ActorContext[Aggregator.Command],
+    aggId: AggregatorIdentifier
+) extends AbstractBehavior[Aggregator.Command](context) {
+  import Aggregator._
+  import FLSystemManager.{
+    RequestTrainer,
+    TrainerRegistered,
+    RequestAggregator,
+    AggregatorRegistered,
+    RequestRealTimeGraph
+  }
 
-    // TODO
-    // Add state and persistent information
+  // TODO
+  // Add state and persistent information
 
-    // List of Aggregators which are children of this aggregator
-    var aggregatorIdsToRef : MutableMap[AggregatorIdentifier, ActorRef[Aggregator.Command]] = MutableMap.empty
+  // List of Aggregators which are children of this aggregator
+  var aggregatorIdsToRef: MutableMap[AggregatorIdentifier, ActorRef[Aggregator.Command]] =
+    MutableMap.empty
 
-    // List of trainers which are children of this aggregator
-    var trainerIdsToRef : MutableMap[TrainerIdentifier, ActorRef[Trainer.Command]] = MutableMap.empty
+  // List of trainers which are children of this aggregator
+  var trainerIdsToRef: MutableMap[TrainerIdentifier, ActorRef[Trainer.Command]] =
+    MutableMap.empty
 
-    context.log.info("Aggregator {} started", aggId.toString())
+  context.log.info("Aggregator {} started", aggId.toString())
 
-    def getTrainerRef(trainerId: TrainerIdentifier): ActorRef[Trainer.Command] = {
-        trainerIdsToRef.get(trainerId) match {
-            case Some(actorRef) =>
-                // Need to check whether the trainer parent is valid or not using aggId 
-                actorRef
-            case None =>
-                context.log.info("Creating new Trainer actor for {}", trainerId.toString())
-                val actorRef = context.spawn(Trainer(trainerId), s"trainer-${trainerId.name()}")
-                context.watchWith(actorRef, TrainerTerminated(actorRef, trainerId))
-                trainerIdsToRef += trainerId -> actorRef
-                actorRef
-        }
+  def getTrainerRef(trainerId: TrainerIdentifier): ActorRef[Trainer.Command] = {
+    trainerIdsToRef.get(trainerId) match {
+      case Some(actorRef) =>
+        // Need to check whether the trainer parent is valid or not using aggId
+        actorRef
+      case None =>
+        context.log.info(
+          "Creating new Trainer actor for {}",
+          trainerId.toString()
+        )
+        val actorRef =
+          context.spawn(Trainer(trainerId), s"trainer-${trainerId.name()}")
+        context.watchWith(actorRef, TrainerTerminated(actorRef, trainerId))
+        trainerIdsToRef += trainerId -> actorRef
+        actorRef
     }
-        
-    def getAggregatorRef(aggregatorId: AggregatorIdentifier): ActorRef[Aggregator.Command] = {
-        aggregatorIdsToRef.get(aggregatorId) match {
-            case Some(actorRef) =>
-                actorRef
-            case None =>
-                context.log.info("Creating new Aggregator actor for {}", aggregatorId.toString())
-                val actorRef = context.spawn(Aggregator(aggregatorId), s"aggregator-${aggregatorId.name()}")
-                context.watchWith(actorRef, AggregatorTerminated(actorRef, aggregatorId))
-                aggregatorIdsToRef += aggregatorId -> actorRef
-                actorRef
+  }
+
+  def getAggregatorRef(
+      aggregatorId: AggregatorIdentifier
+  ): ActorRef[Aggregator.Command] = {
+    aggregatorIdsToRef.get(aggregatorId) match {
+      case Some(actorRef) =>
+        actorRef
+      case None =>
+        context.log.info(
+          "Creating new Aggregator actor for {}",
+          aggregatorId.toString()
+        )
+        val actorRef = context.spawn(
+          Aggregator(aggregatorId),
+          s"aggregator-${aggregatorId.name()}"
+        )
+        context.watchWith(
+          actorRef,
+          AggregatorTerminated(actorRef, aggregatorId)
+        )
+        aggregatorIdsToRef += aggregatorId -> actorRef
+        actorRef
+    }
+  }
+
+  override def onMessage(msg: Command): Behavior[Command] =
+    msg match {
+      case trackMsg @ RequestTrainer(requestId, trainerId, replyTo) =>
+        val aggList = trainerId.getAggregators()
+        if (aggList.find(x => { aggId == x }) == None) {
+          context.log.info(
+            "Aggregator id {} not found in {}",
+            aggId.name(),
+            trainerId.toString()
+          )
+        } else {
+          // Check if the current aggregator is actually parent of trainer
+          if (trainerId.parentIdentifier == aggId) {
+            val actorRef = getTrainerRef(trainerId)
+            replyTo ! TrainerRegistered(requestId, actorRef)
+          } else {
+            // Getting the next aggregator to send the message to
+            val childAggIndex = aggList.indexOf(aggId) + 1
+            val childAgg = aggList(childAggIndex)
+            val aggRef = getAggregatorRef(childAgg)
+            aggRef ! trackMsg
+          }
         }
+        this
+
+      case trackMsg @ RequestAggregator(requestId, aggregatorId, replyTo) =>
+        // Special case of aggregatorId being equal to currentId
+        if (aggregatorId == aggId) {
+          context.log.info(
+            "Aggregator id {} is same as current one",
+            aggregatorId.toString()
+          )
+        } else {
+          val aggList = aggregatorId.getAggregators()
+          if (aggList.find(x => { aggId == x }) == None) {
+            context.log.info(
+              "Aggregator id {} not found in {}",
+              aggId.name(),
+              aggregatorId.toString()
+            )
+          } else {
+            // Check if the current aggregator is actually parent of requested one
+            if (aggregatorId.parentIdentifier == aggId) {
+              val actorRef = getAggregatorRef(aggregatorId)
+              replyTo ! AggregatorRegistered(requestId, actorRef)
+            } else {
+              // Getting the next aggregator to send the message to
+              val childAggIndex = aggList.indexOf(aggId) + 1
+              val childAgg = aggList(childAggIndex)
+              val aggRef = getAggregatorRef(childAgg)
+              aggRef ! trackMsg
+            }
+          }
+        }
+        this
+
+      case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
+        entity match {
+          case Left(x) =>
+            context.log.info(
+              "Cannot get realTimeGraph for an orchestrator entity: got {}",
+              x.toString()
+            )
+
+          case Right(x) =>
+            if (aggId == x) {
+              // return/build the current node's realTimeGraph
+              context.log.info(
+                "Creating new realTimeGraph query actor for {}",
+                entity
+              )
+              context.spawnAnonymous(
+                RealTimeGraphQuery(
+                  creator = entity,
+                  aggIdToRefMap = aggregatorIdsToRef.toMap,
+                  traIds = Some(trainerIdsToRef.keys.toList),
+                  requestId = requestId,
+                  requester = replyTo,
+                  timeout = 30.seconds
+                )
+              )
+            } else {
+              val aggList = x.getAggregators()
+              if (aggList.find(y => { aggId == y }) == None) {
+                context.log.info(
+                  "Aggregator with id {} not found in {}",
+                  aggId.name(),
+                  x.toString()
+                )
+                this
+              }
+
+              val childAggIndex = aggList.indexOf(aggId) + 1
+              val childAgg = aggList(childAggIndex)
+              val aggRef = getAggregatorRef(childAgg)
+              aggRef ! trackMsg
+            }
+        }
+        this
+
+      case AggregatorTerminated(actor, aggId) =>
+        context.log.info(
+          "Aggregator with id {} has been terminated",
+          aggId.toString()
+        )
+        // TODO
+        this
+
+      case TrainerTerminated(actor, traId) =>
+        context.log.info(
+          "Trainer with id {} has been terminated",
+          traId.toString()
+        )
+        // TODO
+        this
     }
 
-    override def onMessage(msg: Command): Behavior[Command] =
-
-        msg match {
-            case trackMsg @ RequestTrainer(requestId, trainerId, replyTo) =>
-                val aggList = trainerId.getAggregators()
-                if (aggList.find(x => {aggId == x}) == None) {
-                    context.log.info("Aggregator id {} not found in {}", aggId.name(), trainerId.toString())
-                } else {
-                    // Check if the current aggregator is actually parent of trainer
-                    if (trainerId.parentIdentifier == aggId) {
-                        val actorRef = getTrainerRef(trainerId)
-                        replyTo ! TrainerRegistered(requestId, actorRef)
-                    } else {
-                        // Getting the next aggregator to send the message to
-                        val childAggIndex = aggList.indexOf(aggId)+1
-                        val childAgg = aggList(childAggIndex)
-                        val aggRef = getAggregatorRef(childAgg)
-                        aggRef ! trackMsg
-                    }
-                }
-                this
-
-            case trackMsg @ RequestAggregator(requestId, aggregatorId , replyTo) =>
-
-                // Special case of aggregatorId being equal to currentId
-                if (aggregatorId == aggId) {
-                    context.log.info("Aggregator id {} is same as current one", aggregatorId.toString())
-                } else {
-                    val aggList = aggregatorId.getAggregators()
-                    if (aggList.find(x => {aggId == x}) == None) {
-                        context.log.info("Aggregator id {} not found in {}", aggId.name(), aggregatorId.toString())
-                    } else {
-                        // Check if the current aggregator is actually parent of requested one
-                        if (aggregatorId.parentIdentifier == aggId) {
-                            val actorRef = getAggregatorRef(aggregatorId)
-                            replyTo ! AggregatorRegistered(requestId, actorRef)
-                        } else {
-                            // Getting the next aggregator to send the message to
-                            val childAggIndex = aggList.indexOf(aggId)+1
-                            val childAgg = aggList(childAggIndex)
-                            val aggRef = getAggregatorRef(childAgg)
-                            aggRef ! trackMsg
-                        }
-                    }
-                }
-                this    
-            
-            case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
-                entity match {
-                    case Left(x) => 
-                        context.log.info("Cannot get realTimeGraph for an orchestrator entity: got {}", x.toString())
-
-                    case Right(x) => 
-                        if (aggId == x) {
-                            // return/build the current node's realTimeGraph
-                            context.log.info("Creating new realTimeGraph query actor for {}", entity)
-                            context.spawnAnonymous(RealTimeGraphQuery(
-                              creator = entity,
-                              aggIdToRefMap = aggregatorIdsToRef.toMap,
-                              traIds = Some(trainerIdsToRef.keys.toList),
-                              requestId = requestId,
-                              requester = replyTo,
-                              timeout = 30.seconds
-                            ))
-                        } else {
-                            val aggList = x.getAggregators()
-                            if (aggList.find(y => {aggId == y}) == None) {
-                                context.log.info("Aggregator with id {} not found in {}", aggId.name(), x.toString())
-                                this
-                            }
-
-                            val childAggIndex = aggList.indexOf(aggId)+1
-                            val childAgg = aggList(childAggIndex)
-                            val aggRef = getAggregatorRef(childAgg)
-                            aggRef ! trackMsg
-                        }
-                }
-                this
-            
-            case AggregatorTerminated(actor, aggId) =>
-                context.log.info("Aggregator with id {} has been terminated", aggId.toString())
-                // TODO
-                this
-            
-            case TrainerTerminated(actor, traId) =>
-                context.log.info("Trainer with id {} has been terminated", traId.toString())
-                // TODO
-                this
-        }
-    
-    override def onSignal: PartialFunction[Signal,Behavior[Command]] = {
-        case PostStop =>
-            context.log.info("Aggregator {} stopped", aggId.toString())
-            this
-    }
+  override def onSignal: PartialFunction[Signal, Behavior[Command]] = { case PostStop =>
+    context.log.info("Aggregator {} stopped", aggId.toString())
+    this
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/FLSystemManager.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/FLSystemManager.scala
@@ -12,123 +12,159 @@ import akka.actor.typed.Signal
 import akka.actor.typed.PostStop
 
 object FLSystemManager {
-    def apply(): Behavior[Command] =
-        Behaviors.setup[Command](new FLSystemManager(_))
+  def apply(): Behavior[Command] =
+    Behaviors.setup[Command](new FLSystemManager(_))
 
-    sealed trait Command
+  sealed trait Command
 
-    // Creating + Getting the actor references
-    final case class RequestOrchestrator(requestId: Long, orcId: OrchestratorIdentifier, replyTo: ActorRef[OrchestratorRegistered])
-        extends FLSystemManager.Command
-    
-    final case class OrchestratorRegistered(requestId: Long, actor: ActorRef[Orchestrator.Command])
+  // Creating + Getting the actor references
+  final case class RequestOrchestrator(
+      requestId: Long,
+      orcId: OrchestratorIdentifier,
+      replyTo: ActorRef[OrchestratorRegistered]
+  ) extends FLSystemManager.Command
 
-    final case class RequestAggregator(requestId: Long, aggId: AggregatorIdentifier, replyTo: ActorRef[AggregatorRegistered])
-        extends FLSystemManager.Command
-        with Orchestrator.Command
-        with Aggregator.Command
-    
-    final case class AggregatorRegistered(requestId: Long, actor: ActorRef[Aggregator.Command])
+  final case class OrchestratorRegistered(
+      requestId: Long,
+      actor: ActorRef[Orchestrator.Command]
+  )
 
-    final case class RequestTrainer(requestId: Long, traId: TrainerIdentifier, replyTo: ActorRef[TrainerRegistered])
-        extends FLSystemManager.Command
-        with Orchestrator.Command
-        with Aggregator.Command
-    
-    final case class TrainerRegistered(requestId: Long, actor: ActorRef[Trainer.Command])
-    
-    // In case of an Orchestrator Termination
-    private final case class OrchestratorTerminated(actor: ActorRef[Orchestrator.Command], orcId: OrchestratorIdentifier)
-        extends FLSystemManager.Command
+  final case class RequestAggregator(
+      requestId: Long,
+      aggId: AggregatorIdentifier,
+      replyTo: ActorRef[AggregatorRegistered]
+  ) extends FLSystemManager.Command
+      with Orchestrator.Command
+      with Aggregator.Command
 
-    // Requesting RealTimeGraph
-    final case class RequestRealTimeGraph(requestId: Long, entity: Either[OrchestratorIdentifier, AggregatorIdentifier], replyTo: ActorRef[RespondRealTimeGraph])
-        extends FLSystemManager.Command
-        with Orchestrator.Command
-        with Aggregator.Command
-    
-    final case class RespondRealTimeGraph(requestId: Long, realTimeGraph: TopologyTree)
+  final case class AggregatorRegistered(
+      requestId: Long,
+      actor: ActorRef[Aggregator.Command]
+  )
 
-    // Start cycle
-    // TODO
-    final case class StartCycle(requestId: Long, replyTo: ActorRef[RespondModel]) extends FLSystemManager.Command
-    final case class RespondModel(requestId: Long)
+  final case class RequestTrainer(
+      requestId: Long,
+      traId: TrainerIdentifier,
+      replyTo: ActorRef[TrainerRegistered]
+  ) extends FLSystemManager.Command
+      with Orchestrator.Command
+      with Aggregator.Command
 
-    // TODO
-    // Add more messages
+  final case class TrainerRegistered(
+      requestId: Long,
+      actor: ActorRef[Trainer.Command]
+  )
+
+  // In case of an Orchestrator Termination
+  private final case class OrchestratorTerminated(
+      actor: ActorRef[Orchestrator.Command],
+      orcId: OrchestratorIdentifier
+  ) extends FLSystemManager.Command
+
+  // Requesting RealTimeGraph
+  final case class RequestRealTimeGraph(
+      requestId: Long,
+      entity: Either[OrchestratorIdentifier, AggregatorIdentifier],
+      replyTo: ActorRef[RespondRealTimeGraph]
+  ) extends FLSystemManager.Command
+      with Orchestrator.Command
+      with Aggregator.Command
+
+  final case class RespondRealTimeGraph(
+      requestId: Long,
+      realTimeGraph: TopologyTree
+  )
+
+  // Start cycle
+  // TODO
+  final case class StartCycle(requestId: Long, replyTo: ActorRef[RespondModel]) extends FLSystemManager.Command
+  final case class RespondModel(requestId: Long)
+
+  // TODO
+  // Add more messages
 }
 
-class FLSystemManager(context: ActorContext[FLSystemManager.Command]) extends AbstractBehavior[FLSystemManager.Command](context) {
-    import FLSystemManager._
+class FLSystemManager(context: ActorContext[FLSystemManager.Command])
+    extends AbstractBehavior[FLSystemManager.Command](context) {
+  import FLSystemManager._
 
-    // TODO
-    // Topology ??
-    // State Information
-    var orcIdToRef : MutableMap[OrchestratorIdentifier, ActorRef[Orchestrator.Command]] = MutableMap.empty
+  // TODO
+  // Topology ??
+  // State Information
+  var orcIdToRef: MutableMap[OrchestratorIdentifier, ActorRef[Orchestrator.Command]] =
+    MutableMap.empty
 
-    context.log.info("FLSystemManager Started")
+  context.log.info("FLSystemManager Started")
 
-    private def getOrchestratorRef(orcId: OrchestratorIdentifier): ActorRef[Orchestrator.Command] = {
+  private def getOrchestratorRef(
+      orcId: OrchestratorIdentifier
+  ): ActorRef[Orchestrator.Command] = {
+    orcIdToRef.get(orcId) match {
+      case Some(actorRef) =>
+        actorRef
+      case None =>
+        context.log.info("Creating new orchestrator actor for {}", orcId.name())
+        val actorRef =
+          context.spawn(Orchestrator(orcId), s"orchestrator-${orcId.name()}")
+        context.watchWith(actorRef, OrchestratorTerminated(actorRef, orcId))
+        orcIdToRef += orcId -> actorRef
+        actorRef
+    }
+  }
+
+  override def onMessage(msg: Command): Behavior[Command] =
+    msg match {
+      case RequestOrchestrator(requestId, orcId, replyTo) =>
+        val actorRef = getOrchestratorRef(orcId)
+        replyTo ! OrchestratorRegistered(requestId, actorRef)
+        this
+
+      case trackMsg @ RequestAggregator(requestId, aggId, replyTo) =>
+        val orcId = aggId.getOrchestrator()
+
+        val orchestratorRef = getOrchestratorRef(orcId)
+        orchestratorRef ! trackMsg
+        this
+
+      case trackMsg @ RequestTrainer(requestId, traId, replyTo) =>
+        val orcId = traId.getOrchestrator()
+
+        val orchestratorRef = getOrchestratorRef(orcId)
+        orchestratorRef ! trackMsg
+        this
+
+      case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
+        val orcId = entity match {
+          case Left(x)  => x
+          case Right(x) => x.getOrchestrator()
+        }
+
         orcIdToRef.get(orcId) match {
-            case Some(actorRef) =>
-                actorRef
-            case None =>
-                context.log.info("Creating new orchestrator actor for {}", orcId.name())
-                val actorRef = context.spawn(Orchestrator(orcId), s"orchestrator-${orcId.name()}")
-                context.watchWith(actorRef, OrchestratorTerminated(actorRef, orcId))
-                orcIdToRef += orcId -> actorRef
-                actorRef
+          case Some(actorRef) =>
+            actorRef ! trackMsg
+          case None =>
+            context.log.info(
+              "Orchestrator with id {} does not exist, can't request realTimeGraph",
+              orcId.name()
+            )
         }
+        this
+
+      case StartCycle(requestId, replyTo) =>
+        // TODO
+        this
+
+      case OrchestratorTerminated(actor, orcId) =>
+        context.log.info(
+          "Orchestrator with id {} has been terminated",
+          orcId.name()
+        )
+        // TODO
+        this
     }
 
-    override def onMessage(msg: Command): Behavior[Command] =
-        msg match {
-            case RequestOrchestrator(requestId, orcId, replyTo) =>
-                val actorRef = getOrchestratorRef(orcId)
-                replyTo ! OrchestratorRegistered(requestId, actorRef)
-                this
-            
-            case trackMsg @ RequestAggregator(requestId, aggId, replyTo) =>
-                val orcId = aggId.getOrchestrator()
-
-                val orchestratorRef = getOrchestratorRef(orcId)
-                orchestratorRef ! trackMsg
-                this
-            
-            case trackMsg @ RequestTrainer(requestId, traId, replyTo) =>
-                val orcId = traId.getOrchestrator()
-
-                val orchestratorRef = getOrchestratorRef(orcId)
-                orchestratorRef ! trackMsg
-                this
-            
-            case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
-                val orcId = entity match {
-                    case Left(x) => x
-                    case Right(x) => x.getOrchestrator()
-                }
-
-                orcIdToRef.get(orcId) match {
-                    case Some(actorRef) =>
-                        actorRef ! trackMsg
-                    case None =>
-                        context.log.info("Orchestrator with id {} does not exist, can't request realTimeGraph", orcId.name())
-                }
-                this
-            
-            case StartCycle(requestId, replyTo) =>
-                // TODO
-                this
-            
-            case OrchestratorTerminated(actor, orcId) =>
-                context.log.info("Orchestrator with id {} has been terminated", orcId.name())
-                // TODO
-                this
-        }
-
-    override def onSignal: PartialFunction[Signal,Behavior[Command]] = {
-        case PostStop =>
-            context.log.info("FLSystemManager Stopped")
-            this
-    }
+  override def onSignal: PartialFunction[Signal, Behavior[Command]] = { case PostStop =>
+    context.log.info("FLSystemManager Stopped")
+    this
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/Main.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/Main.scala
@@ -3,9 +3,9 @@ package org.nimbleedge.envisedge
 import models._
 
 object Main {
-    def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit = {
 
-        /*
+    /*
         The graphical structure of the topology below
 
             O1
@@ -17,59 +17,59 @@ object Main {
                  ├── T3
                  ├── T4
                  └── A3
-                     ├── T5 
+                     ├── T5
                      └── T6
 
-        */
-        val o1 = OrchestratorIdentifier("O1")
-        val a1 = AggregatorIdentifier(o1, "A1")
-        val a2 = AggregatorIdentifier(o1, "A2")
-        val a3 = AggregatorIdentifier(a2, "A3")
-        val t1 = TrainerIdentifier(a1, "T1")
-        val t2 = TrainerIdentifier(a1, "T2")
-        val t3 = TrainerIdentifier(a2, "T3")
-        val t4 = TrainerIdentifier(a2, "T4")
-        val t5 = TrainerIdentifier(a3, "T5")
-        val t6 = TrainerIdentifier(a3, "T6")
+     */
+    val o1 = OrchestratorIdentifier("O1")
+    val a1 = AggregatorIdentifier(o1, "A1")
+    val a2 = AggregatorIdentifier(o1, "A2")
+    val a3 = AggregatorIdentifier(a2, "A3")
+    val t1 = TrainerIdentifier(a1, "T1")
+    val t2 = TrainerIdentifier(a1, "T2")
+    val t3 = TrainerIdentifier(a2, "T3")
+    val t4 = TrainerIdentifier(a2, "T4")
+    val t5 = TrainerIdentifier(a3, "T5")
+    val t6 = TrainerIdentifier(a3, "T6")
 
-        /*
+    /*
         The graphical structure of the topology below
 
             O2
              ├── A21
              │   ├── T21
              │   └── A23
-             |       ├── T23 
+             |       ├── T23
              |       └── T24
              |
              └── A22
                  ├── T22
                  └── T25
 
-        */
-        val o2 = OrchestratorIdentifier("O2")
-        val a21 = AggregatorIdentifier(o2, "A21")
-        val a22 = AggregatorIdentifier(o2, "A22")
-        val a23 = AggregatorIdentifier(a21, "A23")
-        val t21 = TrainerIdentifier(a21, "T21")
-        val t22 = TrainerIdentifier(a22, "T22")
-        val t23 = TrainerIdentifier(a23, "T23")
-        val t24 = TrainerIdentifier(a23, "T24")
-        val t25 = TrainerIdentifier(a22, "T25")
+     */
+    val o2 = OrchestratorIdentifier("O2")
+    val a21 = AggregatorIdentifier(o2, "A21")
+    val a22 = AggregatorIdentifier(o2, "A22")
+    val a23 = AggregatorIdentifier(a21, "A23")
+    val t21 = TrainerIdentifier(a21, "T21")
+    val t22 = TrainerIdentifier(a22, "T22")
+    val t23 = TrainerIdentifier(a23, "T23")
+    val t24 = TrainerIdentifier(a23, "T24")
+    val t25 = TrainerIdentifier(a22, "T25")
 
-        println(t1.toString())
-        println(t2.toString())
-        println(t3.toString())
-        println(t4.toString())
-        println(t5.toString())
+    println(t1.toString())
+    println(t2.toString())
+    println(t3.toString())
+    println(t4.toString())
+    println(t5.toString())
 
-        println(t21.toString())
-        println(t22.toString())
-        println(t23.toString())
-        println(t24.toString())
-        println(t25.toString())
-        println(t22.toList())
+    println(t21.toString())
+    println(t22.toString())
+    println(t23.toString())
+    println(t24.toString())
+    println(t25.toString())
+    println(t22.toList())
 
-        println(a2.getChildren())
-    }
+    println(a2.getChildren())
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/NimbleFLSimulator.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/NimbleFLSimulator.scala
@@ -3,7 +3,7 @@ package org.nimbleedge.envisedge
 import akka.actor.typed.ActorSystem
 
 object NimbleFLSimulator {
-	def main(args: Array[String]): Unit = {
-		ActorSystem[Nothing](SimulatorSupervisor(), "nimble-fl-simulator")
-	}
+  def main(args: Array[String]): Unit = {
+    ActorSystem[Nothing](SimulatorSupervisor(), "nimble-fl-simulator")
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/RealTimeGraphQuery.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/RealTimeGraphQuery.scala
@@ -11,133 +11,151 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.PostStop
 import akka.actor.typed.Signal
 
-import FLSystemManager.{ RespondRealTimeGraph }
+import FLSystemManager.{RespondRealTimeGraph}
 
 // Map of Aggregator Identifiers is compulsory
 // List of Trainer Identifiers is optional
 
 object RealTimeGraphQuery {
-	def apply(
-		creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
-		aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
-		traIds: Option[List[TrainerIdentifier]],
-		requestId: Long,
-		requester: ActorRef[RespondRealTimeGraph],
-		timeout: FiniteDuration
-	) : Behavior[Command] = {
-		Behaviors.setup { context =>
-			Behaviors.withTimers { timers =>
-				new RealTimeGraphQuery(creator, aggIdToRefMap, traIds, requestId, requester, timeout, context, timers)
-			}
-		}
-	}
+  def apply(
+      creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
+      aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
+      traIds: Option[List[TrainerIdentifier]],
+      requestId: Long,
+      requester: ActorRef[RespondRealTimeGraph],
+      timeout: FiniteDuration
+  ): Behavior[Command] = {
+    Behaviors.setup { context =>
+      Behaviors.withTimers { timers =>
+        new RealTimeGraphQuery(
+          creator,
+          aggIdToRefMap,
+          traIds,
+          requestId,
+          requester,
+          timeout,
+          context,
+          timers
+        )
+      }
+    }
+  }
 
-	trait Command
-	private case object CollectionTimeout extends Command
+  trait Command
+  private case object CollectionTimeout extends Command
 
-	final case class WrappedRespondRealTimeGraph(response: RespondRealTimeGraph) extends Command
+  final case class WrappedRespondRealTimeGraph(response: RespondRealTimeGraph) extends Command
 
-	private final case class AggregatorTerminated(aggId: AggregatorIdentifier) extends Command
+  private final case class AggregatorTerminated(aggId: AggregatorIdentifier) extends Command
 }
 
 class RealTimeGraphQuery(
-	creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
-	aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
-	traIds: Option[List[TrainerIdentifier]],
-	requestId: Long,
-	requester: ActorRef[RespondRealTimeGraph],
-	timeout: FiniteDuration,
-	context: ActorContext[RealTimeGraphQuery.Command],
-	timers: TimerScheduler[RealTimeGraphQuery.Command]
+    creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
+    aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
+    traIds: Option[List[TrainerIdentifier]],
+    requestId: Long,
+    requester: ActorRef[RespondRealTimeGraph],
+    timeout: FiniteDuration,
+    context: ActorContext[RealTimeGraphQuery.Command],
+    timers: TimerScheduler[RealTimeGraphQuery.Command]
 ) extends AbstractBehavior[RealTimeGraphQuery.Command](context) {
-	import RealTimeGraphQuery._
+  import RealTimeGraphQuery._
 
-	timers.startSingleTimer(CollectionTimeout, CollectionTimeout, timeout)
+  timers.startSingleTimer(CollectionTimeout, CollectionTimeout, timeout)
 
-	private val respondRealTimeGraphAdapter = context.messageAdapter(WrappedRespondRealTimeGraph.apply)
+  private val respondRealTimeGraphAdapter =
+    context.messageAdapter(WrappedRespondRealTimeGraph.apply)
 
-	private var repliesSoFar = Map.empty[AggregatorIdentifier, TopologyTree]
-	private var stillWaiting = aggIdToRefMap.keySet
+  private var repliesSoFar = Map.empty[AggregatorIdentifier, TopologyTree]
+  private var stillWaiting = aggIdToRefMap.keySet
 
-  	context.log.info("RealTimeGraphQuery Actor for {} started", creator)
+  context.log.info("RealTimeGraphQuery Actor for {} started", creator)
 
-	if (aggIdToRefMap.isEmpty) {
-		respondWhenAllCollected()
-	} else {
-		aggIdToRefMap.foreach {
-			case (aggId, aggRef) =>
-				context.watchWith(aggRef, AggregatorTerminated(aggId))
-				aggRef ! FLSystemManager.RequestRealTimeGraph(0, Right(aggId), respondRealTimeGraphAdapter)
-		}
-	}
+  if (aggIdToRefMap.isEmpty) {
+    respondWhenAllCollected()
+  } else {
+    aggIdToRefMap.foreach { case (aggId, aggRef) =>
+      context.watchWith(aggRef, AggregatorTerminated(aggId))
+      aggRef ! FLSystemManager.RequestRealTimeGraph(
+        0,
+        Right(aggId),
+        respondRealTimeGraphAdapter
+      )
+    }
+  }
 
-	override def onMessage(msg: Command): Behavior[Command] =
-		msg match {
-			case WrappedRespondRealTimeGraph(response) => onRespondRealTimeGraph(response)
-			case AggregatorTerminated(aggId) 	  => onAggregatorTerminated(aggId)
-			case CollectionTimeout 				  => onCollectionTimeout()
-		}
+  override def onMessage(msg: Command): Behavior[Command] =
+    msg match {
+      case WrappedRespondRealTimeGraph(response) =>
+        onRespondRealTimeGraph(response)
+      case AggregatorTerminated(aggId) => onAggregatorTerminated(aggId)
+      case CollectionTimeout           => onCollectionTimeout()
+    }
 
-	private def onRespondRealTimeGraph(response: RespondRealTimeGraph) : Behavior[Command] = {
-		val realTimeGraph = response.realTimeGraph
-		val aggId : AggregatorIdentifier = response.realTimeGraph match {
+  private def onRespondRealTimeGraph(
+      response: RespondRealTimeGraph
+  ): Behavior[Command] = {
+    val realTimeGraph = response.realTimeGraph
+    val aggId: AggregatorIdentifier = response.realTimeGraph match {
 
-			// The Topology Tree will always be a node since
-			// We are requesting realTimeGraph only from Orchestrator/Aggregators.
+      // The Topology Tree will always be a node since
+      // We are requesting realTimeGraph only from Orchestrator/Aggregators.
 
-			case Leaf(x) => throw new NotImplementedError
-			case Node(value, children) => value match {
+      case Leaf(x) => throw new NotImplementedError
+      case Node(value, children) =>
+        value match {
 
-				// OrchestratorIdentifier is never used!
-				// The entity received here should not be Orchestrator Identifier
-				// Since these are messages which will be received by self.
+          // OrchestratorIdentifier is never used!
+          // The entity received here should not be Orchestrator Identifier
+          // Since these are messages which will be received by self.
 
-				case Left(x) => throw new NotImplementedError
-				case Right(x) => x
-			}
-		}
+          case Left(x)  => throw new NotImplementedError
+          case Right(x) => x
+        }
+    }
 
-		repliesSoFar += (aggId -> realTimeGraph)
-		stillWaiting -= aggId
-		respondWhenAllCollected()
-	}
+    repliesSoFar += (aggId -> realTimeGraph)
+    stillWaiting -= aggId
+    respondWhenAllCollected()
+  }
 
-	private def onAggregatorTerminated(aggId: AggregatorIdentifier): Behavior[Command] = {
-		if (stillWaiting(aggId)) {
-			// Send the empty List of children when Aggregator terminated.
-			repliesSoFar += (aggId -> Node(Right(aggId), Set.empty))
-			stillWaiting -= aggId
-		}
-		respondWhenAllCollected()
-	}
+  private def onAggregatorTerminated(
+      aggId: AggregatorIdentifier
+  ): Behavior[Command] = {
+    if (stillWaiting(aggId)) {
+      // Send the empty List of children when Aggregator terminated.
+      repliesSoFar += (aggId -> Node(Right(aggId), Set.empty))
+      stillWaiting -= aggId
+    }
+    respondWhenAllCollected()
+  }
 
-	private def onCollectionTimeout(): Behavior[Command] = {
-		// Send the empty List of children for Aggregators who didn't respond
-		repliesSoFar ++= stillWaiting.map(aggId => aggId -> Node(Right(aggId), Set.empty))
-		stillWaiting = Set.empty
-		respondWhenAllCollected()
-	}
+  private def onCollectionTimeout(): Behavior[Command] = {
+    // Send the empty List of children for Aggregators who didn't respond
+    repliesSoFar ++= stillWaiting.map(aggId => aggId -> Node(Right(aggId), Set.empty))
+    stillWaiting = Set.empty
+    respondWhenAllCollected()
+  }
 
-	private def respondWhenAllCollected(): Behavior[Command] = {
-		if (stillWaiting.isEmpty) {
-			// Construct a tree and return to requester
-			val children : Set[TopologyTree] = {
-				val trainers: Set[TopologyTree] = traIds match {
-					case Some(list) => list.map(traId => Leaf(traId)).toSet
-					case None => Set.empty
-				}
-				repliesSoFar.values.toSet ++ trainers
-			}
-			requester ! RespondRealTimeGraph(requestId, Node(creator, children))	
-			Behaviors.stopped
-		} else {
-			this
-		}
-	}
+  private def respondWhenAllCollected(): Behavior[Command] = {
+    if (stillWaiting.isEmpty) {
+      // Construct a tree and return to requester
+      val children: Set[TopologyTree] = {
+        val trainers: Set[TopologyTree] = traIds match {
+          case Some(list) => list.map(traId => Leaf(traId)).toSet
+          case None       => Set.empty
+        }
+        repliesSoFar.values.toSet ++ trainers
+      }
+      requester ! RespondRealTimeGraph(requestId, Node(creator, children))
+      Behaviors.stopped
+    } else {
+      this
+    }
+  }
 
-	override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
-		case PostStop =>
-			context.log.info("RealTimeGraphQuery Actor for {} stopped", creator)
-			this
-	}
+  override def onSignal: PartialFunction[Signal, Behavior[Command]] = { case PostStop =>
+    context.log.info("RealTimeGraphQuery Actor for {} stopped", creator)
+    this
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/SimulatorSupervisor.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/SimulatorSupervisor.scala
@@ -8,21 +8,20 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 
 object SimulatorSupervisor {
-	// Update this to manager to other entities
-	def apply(): Behavior[Nothing] =
-		Behaviors.setup[Nothing](new SimulatorSupervisor(_))
+  // Update this to manager to other entities
+  def apply(): Behavior[Nothing] =
+    Behaviors.setup[Nothing](new SimulatorSupervisor(_))
 }
 
 class SimulatorSupervisor(context: ActorContext[Nothing]) extends AbstractBehavior[Nothing](context) {
-	context.log.info("Simulator Supervisor started")
+  context.log.info("Simulator Supervisor started")
 
-	override def onMessage(msg: Nothing): Behavior[Nothing] = {
-		Behaviors.unhandled
-	}
+  override def onMessage(msg: Nothing): Behavior[Nothing] = {
+    Behaviors.unhandled
+  }
 
-	override def onSignal: PartialFunction[Signal, Behavior[Nothing]] = {
-		case PostStop =>
-			context.log.info("Simulator Supervisor stopped")
-			this
-	}
+  override def onSignal: PartialFunction[Signal, Behavior[Nothing]] = { case PostStop =>
+    context.log.info("Simulator Supervisor stopped")
+    this
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/Trainer.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/Trainer.scala
@@ -10,33 +10,33 @@ import akka.actor.typed.Signal
 import akka.actor.typed.PostStop
 
 object Trainer {
-    def apply(traId: TrainerIdentifier): Behavior[Command] =
-        Behaviors.setup(new Trainer(_, traId))
-    
-    trait Command
+  def apply(traId: TrainerIdentifier): Behavior[Command] =
+    Behaviors.setup(new Trainer(_, traId))
 
-    // TODO
-    // Add messages here
+  trait Command
+
+  // TODO
+  // Add messages here
 }
 
-class Trainer(context: ActorContext[Trainer.Command], traId: TrainerIdentifier) extends AbstractBehavior[Trainer.Command](context) {
-    import Trainer._
+class Trainer(context: ActorContext[Trainer.Command], traId: TrainerIdentifier)
+    extends AbstractBehavior[Trainer.Command](context) {
+  import Trainer._
 
-    // TODO
-    // Add state and persistent information
+  // TODO
+  // Add state and persistent information
 
-    context.log.info("Trainer {} started", traId.toString())
+  context.log.info("Trainer {} started", traId.toString())
 
-    override def onMessage(msg: Command): Behavior[Command] =
-        msg match {
-            // TODO
-            case _ =>
-                this
-        }
-    
-    override def onSignal: PartialFunction[Signal,Behavior[Command]] = {
-        case PostStop =>
-            context.log.info("Trainer {} stopped", traId.toString())
-            this
+  override def onMessage(msg: Command): Behavior[Command] =
+    msg match {
+      // TODO
+      case _ =>
+        this
     }
+
+  override def onSignal: PartialFunction[Signal, Behavior[Command]] = { case PostStop =>
+    context.log.info("Trainer {} stopped", traId.toString())
+    this
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/models/Identifier.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/models/Identifier.scala
@@ -5,29 +5,28 @@ import java.nio.ByteBuffer
 import scala.collection.mutable.ListBuffer
 
 sealed abstract class Identifier {
-    def name() : String
-    def computeDigest() : Array[Byte]
-    val digest : Array[Byte] = computeDigest()
-    override val hashCode : Int = ByteBuffer.wrap(digest.slice(0,4)).getInt
+  def name(): String
+  def computeDigest(): Array[Byte]
+  val digest: Array[Byte] = computeDigest()
+  override val hashCode: Int = ByteBuffer.wrap(digest.slice(0, 4)).getInt
 
-    def hash(baseName: String, args: List[Identifier]): Array[Byte] = {
-        val md = MD.getInstance("SHA-256")
-        md.reset()
-        md.update(baseName.getBytes("UTF-8"))
-        args.foreach(
-            arg => md.update(arg.digest)
-        )
-        md.digest()
+  def hash(baseName: String, args: List[Identifier]): Array[Byte] = {
+    val md = MD.getInstance("SHA-256")
+    md.reset()
+    md.update(baseName.getBytes("UTF-8"))
+    args.foreach(arg => md.update(arg.digest))
+    md.digest()
+  }
+
+  override def equals(identifier_val: Any): Boolean = {
+    identifier_val match {
+      case i: Identifier =>
+        hashCode == identifier_val.hashCode && MD.isEqual(digest, i.digest)
+      case _ => false
     }
+  }
 
-    override def equals(identifier_val: Any): Boolean = {
-        identifier_val match {
-            case i : Identifier => hashCode == identifier_val.hashCode && MD.isEqual(digest, i.digest)
-            case _ => false
-        }
-    }
-
-    /* Traversal path of the current node from root node.
+  /* Traversal path of the current node from root node.
 
        For example, if we had a structure like:
 
@@ -40,109 +39,133 @@ sealed abstract class Identifier {
             ├── T3
             ├── T4
             └── A3
-                ├── T5 
+                ├── T5
                 └── T6
 
         A2.toList() would return => [O1, A2]
         T5.toList() would return => [O1, A2, A3, T5]
-    */
-    def toList(): List[Identifier] = List.empty
+   */
+  def toList(): List[Identifier] = List.empty
 
-    // Children
-    val children : ListBuffer[Identifier] = ListBuffer.empty
-    def getChildren(): List[Identifier] = children.toList
+  // Children
+  val children: ListBuffer[Identifier] = ListBuffer.empty
+  def getChildren(): List[Identifier] = children.toList
 
-    // TODO
-    // The removal of children from the list has to be done manually
+  // TODO
+  // The removal of children from the list has to be done manually
 }
 
 case class OrchestratorIdentifier(id: String) extends Identifier {
-    // String Representation
-    override def name(): String = id
-    override def toString(): String = id
+  // String Representation
+  override def name(): String = id
+  override def toString(): String = id
 
-    // Get List
-    override def toList(): List[Identifier] = List(this)
+  // Get List
+  override def toList(): List[Identifier] = List(this)
 
-    // Hash digest
-    override def computeDigest(): Array[Byte] = hash("_Orc" + id, List.empty)
+  // Hash digest
+  override def computeDigest(): Array[Byte] = hash("_Orc" + id, List.empty)
 }
 
 case class AggregatorIdentifier(parentIdentifier: Identifier, id: String) extends Identifier {
 
-    // Add into parents children
-    parentIdentifier.children += this
+  // Add into parents children
+  parentIdentifier.children += this
 
-    // String Representation
-    override def name(): String = id
-    override def toString(): String = parentIdentifier.toString() + " -> " + id
+  // String Representation
+  override def name(): String = id
+  override def toString(): String = parentIdentifier.toString() + " -> " + id
 
-    // Get List
-    override def toList(): List[Identifier] = parentIdentifier.toList().appended(this)
+  // Get List
+  override def toList(): List[Identifier] =
+    parentIdentifier.toList().appended(this)
 
-    // Hash digest
-    override def computeDigest(): Array[Byte] = hash("_Agg" + id, parentIdentifier.toList())
+  // Hash digest
+  override def computeDigest(): Array[Byte] =
+    hash("_Agg" + id, parentIdentifier.toList())
 
-    // Get Orchestrator
-    // Always the root node
-    def getOrchestrator(): OrchestratorIdentifier = {
-        val orcId = parentIdentifier.toList().head
-        orcId match {
-            case result @ OrchestratorIdentifier(_) => result
-            case _ => throw new IllegalArgumentException("Orchestrator identifier not available.")
-        }
+  // Get Orchestrator
+  // Always the root node
+  def getOrchestrator(): OrchestratorIdentifier = {
+    val orcId = parentIdentifier.toList().head
+    orcId match {
+      case result @ OrchestratorIdentifier(_) => result
+      case _ =>
+        throw new IllegalArgumentException(
+          "Orchestrator identifier not available."
+        )
     }
+  }
 
-    // Get List of parent aggregators
-    // NOTE: Including the current aggregator identifier
-    def getAggregators(): List[AggregatorIdentifier] = {
-        parentIdentifier match {
-            case OrchestratorIdentifier(_) => List.empty
-            case _ => this.toList().drop(1).map(
-                value => value match {
-                    case result @ AggregatorIdentifier(_, _) => result
-                    case _ => throw new IllegalArgumentException("Aggregator identifier not available.")
-                }
-            )
-        }
+  // Get List of parent aggregators
+  // NOTE: Including the current aggregator identifier
+  def getAggregators(): List[AggregatorIdentifier] = {
+    parentIdentifier match {
+      case OrchestratorIdentifier(_) => List.empty
+      case _ =>
+        this
+          .toList()
+          .drop(1)
+          .map(value =>
+            value match {
+              case result @ AggregatorIdentifier(_, _) => result
+              case _ =>
+                throw new IllegalArgumentException(
+                  "Aggregator identifier not available."
+                )
+            }
+          )
     }
+  }
 }
 
 case class TrainerIdentifier(parentIdentifier: Identifier, id: String) extends Identifier {
 
-    // Add into parents children
-    parentIdentifier.children += this
+  // Add into parents children
+  parentIdentifier.children += this
 
-    // String Representation
-    override def name(): String = id
-    override def toString(): String = parentIdentifier.toString() + " -> " + id
+  // String Representation
+  override def name(): String = id
+  override def toString(): String = parentIdentifier.toString() + " -> " + id
 
-    // Get List
-    override def toList(): List[Identifier] = parentIdentifier.toList().appended(this)
+  // Get List
+  override def toList(): List[Identifier] =
+    parentIdentifier.toList().appended(this)
 
-    // Hash digest
-    override def computeDigest(): Array[Byte] = hash("_Tra" + id, parentIdentifier.toList())
+  // Hash digest
+  override def computeDigest(): Array[Byte] =
+    hash("_Tra" + id, parentIdentifier.toList())
 
-    // Get Orchestrator
-    // Always the root node
-    def getOrchestrator(): OrchestratorIdentifier = {
-        val orcId = parentIdentifier.toList().head
-        orcId match {
-            case result @ OrchestratorIdentifier(_) => result
-            case _ => throw new IllegalArgumentException("Orchestrator identifier not available.")
-        }
+  // Get Orchestrator
+  // Always the root node
+  def getOrchestrator(): OrchestratorIdentifier = {
+    val orcId = parentIdentifier.toList().head
+    orcId match {
+      case result @ OrchestratorIdentifier(_) => result
+      case _ =>
+        throw new IllegalArgumentException(
+          "Orchestrator identifier not available."
+        )
     }
+  }
 
-    // Get List of parent aggregators
-    def getAggregators(): List[AggregatorIdentifier] = {
-        parentIdentifier match {
-            case OrchestratorIdentifier(_) => List.empty
-            case _ => parentIdentifier.toList().drop(1).map(
-                value => value match {
-                    case result @ AggregatorIdentifier(_, _) => result
-                    case _ => throw new IllegalArgumentException("Aggregator identifier not available.")
-                }
-            )
-        }
+  // Get List of parent aggregators
+  def getAggregators(): List[AggregatorIdentifier] = {
+    parentIdentifier match {
+      case OrchestratorIdentifier(_) => List.empty
+      case _ =>
+        parentIdentifier
+          .toList()
+          .drop(1)
+          .map(value =>
+            value match {
+              case result @ AggregatorIdentifier(_, _) => result
+              case _ =>
+                throw new IllegalArgumentException(
+                  "Aggregator identifier not available."
+                )
+            }
+          )
     }
+  }
 }

--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/models/TopologyTree.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/models/TopologyTree.scala
@@ -4,29 +4,30 @@ import java.security.{MessageDigest => MD}
 import java.nio.ByteBuffer
 
 sealed abstract class TopologyTree {
-	def computeDigest() : Array[Byte]
-	val digest : Array[Byte] = computeDigest()
-	override val hashCode : Int = ByteBuffer.wrap(digest.slice(0,4)).getInt
+  def computeDigest(): Array[Byte]
+  val digest: Array[Byte] = computeDigest()
+  override val hashCode: Int = ByteBuffer.wrap(digest.slice(0, 4)).getInt
 
-	def hash(baseName: String, args: Set[TopologyTree]): Array[Byte] = {
-		val md = MD.getInstance("SHA-256")
-		md.reset()
-		md.update(baseName.getBytes("UTF-8"))
+  def hash(baseName: String, args: Set[TopologyTree]): Array[Byte] = {
+    val md = MD.getInstance("SHA-256")
+    md.reset()
+    md.update(baseName.getBytes("UTF-8"))
 
-		// Two Same Sets will always have the same hashcode
-		// Instead of computing hashcode separately for the sets,
-		// We use their internal one.
-		md.update(ByteBuffer.allocate(4).putInt(args.hashCode()).array())
+    // Two Same Sets will always have the same hashcode
+    // Instead of computing hashcode separately for the sets,
+    // We use their internal one.
+    md.update(ByteBuffer.allocate(4).putInt(args.hashCode()).array())
 
-		md.digest()
-	}
+    md.digest()
+  }
 
-	override def equals(identifier_val: Any): Boolean = {
-		identifier_val match {
-			case i : TopologyTree => hashCode == identifier_val.hashCode && MD.isEqual(digest, i.digest)
-			case _ => false
-		}
-	}
+  override def equals(identifier_val: Any): Boolean = {
+    identifier_val match {
+      case i: TopologyTree =>
+        hashCode == identifier_val.hashCode && MD.isEqual(digest, i.digest)
+      case _ => false
+    }
+  }
 }
 
 // Creating Leaf and Node separately for keeping the distinction between Trainers
@@ -34,27 +35,31 @@ sealed abstract class TopologyTree {
 
 // Leaf will always be a TrainerIdentifier
 case class Leaf(value: TrainerIdentifier) extends TopologyTree {
-	override def toString(): String = value.name()
+  override def toString(): String = value.name()
 
-	override def computeDigest(): Array[Byte] = hash("_Leaf" + value.name(), Set.empty)
+  override def computeDigest(): Array[Byte] =
+    hash("_Leaf" + value.name(), Set.empty)
 }
 
 // Node can be only OrchestratorIdentifier or AggregatorIdentifier
 // It should have more that one children
-case class Node(value: Either[OrchestratorIdentifier, AggregatorIdentifier], children: Set[TopologyTree]) extends TopologyTree {
-	override def toString(): String = {
-		val node_value : String = value match {
-			case Left(x) => x.name()
-			case Right(x) => x.name()
-		}
-		node_value + children.mkString("(", ", ", ")")
-	}
+case class Node(
+    value: Either[OrchestratorIdentifier, AggregatorIdentifier],
+    children: Set[TopologyTree]
+) extends TopologyTree {
+  override def toString(): String = {
+    val node_value: String = value match {
+      case Left(x)  => x.name()
+      case Right(x) => x.name()
+    }
+    node_value + children.mkString("(", ", ", ")")
+  }
 
-	override def computeDigest(): Array[Byte] = {
-		val node_value : String = value match {
-			case Left(x) => "_Node_Orc" + x.name()
-			case Right(x) => "_Node_Agg" + x.name()
-		}
-		hash(node_value, children)
-	}
+  override def computeDigest(): Array[Byte] = {
+    val node_value: String = value match {
+      case Left(x)  => "_Node_Orc" + x.name()
+      case Right(x) => "_Node_Agg" + x.name()
+    }
+    hash(node_value, children)
+  }
 }

--- a/scala_core/src/test/scala/org/nimbleedge/envisedgde/AggregatorSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/envisedgde/AggregatorSpec.scala
@@ -4,8 +4,8 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class AggregatorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
-	import models._
+  import models._
 
-	// TODO
-	// Add Aggregator tests here
+  // TODO
+  // Add Aggregator tests here
 }

--- a/scala_core/src/test/scala/org/nimbleedge/envisedgde/FLSystemManagerSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/envisedgde/FLSystemManagerSpec.scala
@@ -6,10 +6,10 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class FLSystemManagerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
-	import models._
-	import FLSystemManager._
+  import models._
+  import FLSystemManager._
 
-    /*
+  /*
 	It will be used for testing.
     The graphical structure of the topology below
 
@@ -22,76 +22,76 @@ class FLSystemManagerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike
              ├── T3
              ├── T4
              └── A3
-                 ├── T5 
+                 ├── T5
                  └── T6
 
-    */
-    val o1 = OrchestratorIdentifier("O1")
-    val a1 = AggregatorIdentifier(o1, "A1")
-    val a2 = AggregatorIdentifier(o1, "A2")
-    val a3 = AggregatorIdentifier(a2, "A3")
-    val t1 = TrainerIdentifier(a1, "T1")
-    val t2 = TrainerIdentifier(a1, "T2")
-    val t3 = TrainerIdentifier(a2, "T3")
-    val t4 = TrainerIdentifier(a2, "T4")
-    val t5 = TrainerIdentifier(a3, "T5")
-    val t6 = TrainerIdentifier(a3, "T6")
+   */
+  val o1 = OrchestratorIdentifier("O1")
+  val a1 = AggregatorIdentifier(o1, "A1")
+  val a2 = AggregatorIdentifier(o1, "A2")
+  val a3 = AggregatorIdentifier(a2, "A3")
+  val t1 = TrainerIdentifier(a1, "T1")
+  val t2 = TrainerIdentifier(a1, "T2")
+  val t3 = TrainerIdentifier(a2, "T3")
+  val t4 = TrainerIdentifier(a2, "T4")
+  val t5 = TrainerIdentifier(a3, "T5")
+  val t6 = TrainerIdentifier(a3, "T6")
 
-	"FLSystemManager actor" must {
-		"be able to register a trainer, orchestrator and aggregator" in {
-			val managerActor = spawn(FLSystemManager())
+  "FLSystemManager actor" must {
+    "be able to register a trainer, orchestrator and aggregator" in {
+      val managerActor = spawn(FLSystemManager())
 
-			// Create Trainer Actors
-			val trainerProbe = createTestProbe[TrainerRegistered]()
+      // Create Trainer Actors
+      val trainerProbe = createTestProbe[TrainerRegistered]()
 
-			managerActor ! RequestTrainer(100, t5, trainerProbe.ref)
-			val registered1 = trainerProbe.receiveMessage()
-			registered1.requestId should ===(100)
-			val trainerActor5 = registered1.actor
+      managerActor ! RequestTrainer(100, t5, trainerProbe.ref)
+      val registered1 = trainerProbe.receiveMessage()
+      registered1.requestId should ===(100)
+      val trainerActor5 = registered1.actor
 
-			managerActor ! RequestTrainer(101, t3, trainerProbe.ref)
-			val registered2 = trainerProbe.receiveMessage()
-			registered2.requestId should ===(101)
-			val trainerActor3 = registered2.actor
+      managerActor ! RequestTrainer(101, t3, trainerProbe.ref)
+      val registered2 = trainerProbe.receiveMessage()
+      registered2.requestId should ===(101)
+      val trainerActor3 = registered2.actor
 
-			trainerActor5 should !==(trainerActor3)
+      trainerActor5 should !==(trainerActor3)
 
-			// Create Aggregators
-			val aggProbe = createTestProbe[AggregatorRegistered]()
+      // Create Aggregators
+      val aggProbe = createTestProbe[AggregatorRegistered]()
 
-			managerActor ! RequestAggregator(102, a1, aggProbe.ref)
-			val registered3 = aggProbe.receiveMessage()
-			registered3.requestId should ===(102)
-			val aggActor1 = registered3.actor
+      managerActor ! RequestAggregator(102, a1, aggProbe.ref)
+      val registered3 = aggProbe.receiveMessage()
+      registered3.requestId should ===(102)
+      val aggActor1 = registered3.actor
 
-			managerActor ! RequestAggregator(103, a2, aggProbe.ref)
-			val registered4 = aggProbe.receiveMessage()
-			registered4.requestId should ===(103)
-			val aggActor2 = registered4.actor
+      managerActor ! RequestAggregator(103, a2, aggProbe.ref)
+      val registered4 = aggProbe.receiveMessage()
+      registered4.requestId should ===(103)
+      val aggActor2 = registered4.actor
 
-			aggActor1 should !==(aggActor2)
+      aggActor1 should !==(aggActor2)
 
-			// Test RealTimeGraph
-			val realTimeGraphProbe = createTestProbe[RespondRealTimeGraph]()
+      // Test RealTimeGraph
+      val realTimeGraphProbe = createTestProbe[RespondRealTimeGraph]()
 
-			managerActor ! RequestRealTimeGraph(104, Left(o1), realTimeGraphProbe.ref)
-			val registered5 = realTimeGraphProbe.receiveMessage(35.seconds)
-			val expectedTree = Node(
-				Left(o1), Set(
-					Node(Right(a1), Set.empty),
-					Node(Right(a2), Set(
-						Leaf(t3),
-						Node(Right(a3), Set(
-							Leaf(t5)))))))
-			registered5.realTimeGraph should ===(expectedTree)
+      managerActor ! RequestRealTimeGraph(104, Left(o1), realTimeGraphProbe.ref)
+      val registered5 = realTimeGraphProbe.receiveMessage(35.seconds)
+      val expectedTree = Node(
+        Left(o1),
+        Set(
+          Node(Right(a1), Set.empty),
+          Node(Right(a2), Set(Leaf(t3), Node(Right(a3), Set(Leaf(t5)))))
+        )
+      )
+      registered5.realTimeGraph should ===(expectedTree)
 
-			// TODO
-			// add more tests here
-		}
+      // TODO
+      // add more tests here
+    }
 
-		// TODO
-		// Add more FLSystemManager tests
-	}
-	// TODO
-	// Add FLSystemManager tests here
+    // TODO
+    // Add more FLSystemManager tests
+  }
+  // TODO
+  // Add FLSystemManager tests here
 }

--- a/scala_core/src/test/scala/org/nimbleedge/envisedgde/OrchestratorSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/envisedgde/OrchestratorSpec.scala
@@ -4,8 +4,8 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class OrchestratorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
-	import models._
+  import models._
 
-	// TODO
-	// Add Orchestrator tests here
+  // TODO
+  // Add Orchestrator tests here
 }

--- a/scala_core/src/test/scala/org/nimbleedge/envisedgde/TrainerSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/envisedgde/TrainerSpec.scala
@@ -4,8 +4,8 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class TrainerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
-	import models._
+  import models._
 
-	// TODO
-	// Add Trainer tests here
+  // TODO
+  // Add Trainer tests here
 }

--- a/scala_core/src/test/scala/org/nimbleedge/envisedgde/models/IdentifierSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/envisedgde/models/IdentifierSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 class IdentifierSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
 
-    /*
+  /*
     The graphical structure of the topology below
 
         O1
@@ -17,104 +17,105 @@ class IdentifierSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
              ├── T3
              ├── T4
              └── A3
-                 ├── T5 
+                 ├── T5
                  └── T6
 
-    */
-    val o1 = OrchestratorIdentifier("O1")
-    val a1 = AggregatorIdentifier(o1, "A1")
-    val a2 = AggregatorIdentifier(o1, "A2")
-    val a3 = AggregatorIdentifier(a2, "A3")
-    val t1 = TrainerIdentifier(a1, "T1")
-    val t2 = TrainerIdentifier(a1, "T2")
-    val t3 = TrainerIdentifier(a2, "T3")
-    val t4 = TrainerIdentifier(a2, "T4")
-    val t5 = TrainerIdentifier(a3, "T5")
-    val t6 = TrainerIdentifier(a3, "T6")
+   */
+  val o1 = OrchestratorIdentifier("O1")
+  val a1 = AggregatorIdentifier(o1, "A1")
+  val a2 = AggregatorIdentifier(o1, "A2")
+  val a3 = AggregatorIdentifier(a2, "A3")
+  val t1 = TrainerIdentifier(a1, "T1")
+  val t2 = TrainerIdentifier(a1, "T2")
+  val t3 = TrainerIdentifier(a2, "T3")
+  val t4 = TrainerIdentifier(a2, "T4")
+  val t5 = TrainerIdentifier(a3, "T5")
+  val t6 = TrainerIdentifier(a3, "T6")
 
-
-    /*
+  /*
     The graphical structure of the topology below
 
         O2
          ├── A21
          │   ├── T21
          │   └── A23
-         |       ├── T23 
+         |       ├── T23
          |       └── T24
          |
          └── A22
              ├── T22
              └── T25
 
-    */
-    val o2 = OrchestratorIdentifier("O2")
-    val a21 = AggregatorIdentifier(o2, "A21")
-    val a22 = AggregatorIdentifier(o2, "A22")
-    val a23 = AggregatorIdentifier(a21, "A23")
-    val t21 = TrainerIdentifier(a21, "T21")
-    val t22 = TrainerIdentifier(a22, "T22")
-    val t23 = TrainerIdentifier(a23, "T23")
-    val t24 = TrainerIdentifier(a23, "T24")
-    val t25 = TrainerIdentifier(a22, "T25")
+   */
+  val o2 = OrchestratorIdentifier("O2")
+  val a21 = AggregatorIdentifier(o2, "A21")
+  val a22 = AggregatorIdentifier(o2, "A22")
+  val a23 = AggregatorIdentifier(a21, "A23")
+  val t21 = TrainerIdentifier(a21, "T21")
+  val t22 = TrainerIdentifier(a22, "T22")
+  val t23 = TrainerIdentifier(a23, "T23")
+  val t24 = TrainerIdentifier(a23, "T24")
+  val t25 = TrainerIdentifier(a22, "T25")
 
-	"Orchestrator Identifier" must {
-		"have string representation equal to its name" in {
-			o1.toString() should ===("O1")
-			o2.toString() should ===("O2")
-		}
+  "Orchestrator Identifier" must {
+    "have string representation equal to its name" in {
+      o1.toString() should ===("O1")
+      o2.toString() should ===("O2")
+    }
 
-		"return a singleton list with toList function" in {
-			val o1toList = o1.toList()
-			o1toList.size should ===(1)
-			o1toList.head match {
-				case result @ OrchestratorIdentifier(x) => x should ===("O1")
-				case _ => fail("Expecting an Orchestrator Identifier, got different type")
-			}
+    "return a singleton list with toList function" in {
+      val o1toList = o1.toList()
+      o1toList.size should ===(1)
+      o1toList.head match {
+        case result @ OrchestratorIdentifier(x) => x should ===("O1")
+        case _ =>
+          fail("Expecting an Orchestrator Identifier, got different type")
+      }
 
-			val o2toList = o2.toList()
-			o2toList.size should ===(1)
-			o2toList.head match {
-				case result @ OrchestratorIdentifier(x) => x should ===("O2")
-				case _ => fail("Expecting an Orchestrator Identifier, got different type")
-			}
-		}	
+      val o2toList = o2.toList()
+      o2toList.size should ===(1)
+      o2toList.head match {
+        case result @ OrchestratorIdentifier(x) => x should ===("O2")
+        case _ =>
+          fail("Expecting an Orchestrator Identifier, got different type")
+      }
+    }
 
-		"should have the correctly populated list of children" in {
-			val o1Children = o1.getChildren()
-			o1Children.size should ===(2)
-			o1Children should contain only (a1, a2)
+    "should have the correctly populated list of children" in {
+      val o1Children = o1.getChildren()
+      o1Children.size should ===(2)
+      o1Children should contain only (a1, a2)
 
-			val o2Children = o2.getChildren()
-			o2Children.size should ===(2)
-			o2Children should contain only (a21, a22)
-		}
-	}
+      val o2Children = o2.getChildren()
+      o2Children.size should ===(2)
+      o2Children should contain only (a21, a22)
+    }
+  }
 
-	"Aggregator Identifier" must {
-		"have string representation equal to node path in tree" in {
-            // A1 and A2 are similar
-            val a1toString = a1.toString()
-            a1toString should startWith ("O1 ")
-            a1toString should endWith (" A1")
+  "Aggregator Identifier" must {
+    "have string representation equal to node path in tree" in {
+      // A1 and A2 are similar
+      val a1toString = a1.toString()
+      a1toString should startWith("O1 ")
+      a1toString should endWith(" A1")
 
-            // Testing A3
-            val a3toString = a3.toString()
-            a3toString should startWith ("O1 ")
-            a3toString should include (" A2 ")
-            a3toString should endWith (" A3")
+      // Testing A3
+      val a3toString = a3.toString()
+      a3toString should startWith("O1 ")
+      a3toString should include(" A2 ")
+      a3toString should endWith(" A3")
 
-            // Testing A23
-            val a23toString = a23.toString()
-            a23toString should startWith ("O2 ")
-            a23toString should include (" A21 ")
-            a23toString should endWith (" A23")
-		}
+      // Testing A23
+      val a23toString = a23.toString()
+      a23toString should startWith("O2 ")
+      a23toString should include(" A21 ")
+      a23toString should endWith(" A23")
+    }
 
-        // TODO
-        // Add more Aggregator Identifier tests
-	}
+    // TODO
+    // Add more Aggregator Identifier tests
+  }
 
-	// TODO
-	// Add Trainer Identifier tests here
+  // TODO
+  // Add Trainer Identifier tests here
 }


### PR DESCRIPTION
## Description
Adds the `.scalafmt.conf` file to scala_core and sbt-scalafmt plugin to use scalafmt within sbt. Only existing code is formatted. No new code is added for ease of review. This will help set and maintain scala code quality standards.

## Relevant Issue
Issue #Tag the issue here

## Affected Dependencies
sbt-scalafmt plugin is added.

## How has this been tested?
Not required

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/NimbleEdge/EnvisEdge/labels)
- [X] My changes are covered by tests
