### PR TITLE
added doc for SimulatorSupervisor.scala

### DIFF
--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/SimulatorSupervisor.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/SimulatorSupervisor.scala
@@ -8,19 +8,43 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 
 object SimulatorSupervisor {
+	/** The behavior of the supervisor actor.
+	  * 
+	  * @return the behavior
+	  */
 	// Update this to manager to other entities
 	def apply(): Behavior[Nothing] =
 		Behaviors.setup[Nothing](new SimulatorSupervisor(_))
 }
 
 class SimulatorSupervisor(context: ActorContext[Nothing]) extends AbstractBehavior[Nothing](context) {
+	/** The behavior of the supervisor actor.
+	  * 
+	  * This is the behavior of the supervisor actor itself. It is the top level behavior of the actor system
+	  * and is responsible for creating the simulation environment and supervising the other actors. It is helped
+	  * by the AbstractBehavior class which provides a lot of useful functionality around the supervision of
+	  * actors.
+	  *
+	  * @param context the actor context
+	  * @return the behavior
+	  */
 	context.log.info("Simulator Supervisor started")
 
 	override def onMessage(msg: Nothing): Behavior[Nothing] = {
+		/** The onMessage method is called when a message is received by the actor.
+		  * 
+		  * @param msg the message
+		  * @return the behavior
+		  */
 		Behaviors.unhandled
 	}
 
 	override def onSignal: PartialFunction[Signal, Behavior[Nothing]] = {
+		/** The onSignal method is called when a signal is received by the actor.
+		  * 
+		  * @param signal the signal
+		  * @return the behavior
+		  */
 		case PostStop =>
 			context.log.info("Simulator Supervisor stopped")
 			this


### PR DESCRIPTION
## Description
This PR adds inline documentation to the scala_core/src/main/scala/org/nimbleedge/envisedge/SimulatorSupervisor.scala file.

## Relevant Issue


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)