### PR TITLE
added doc for Trainer.scala

### DIFF
--- a/scala_core/src/main/scala/org/nimbleedge/envisedge/Trainer.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/envisedge/Trainer.scala
@@ -10,7 +10,11 @@ import akka.actor.typed.Signal
 import akka.actor.typed.PostStop
 
 object Trainer {
+    /**
+     * The behavior of the Trainer actor.
+     */
     def apply(traId: TrainerIdentifier): Behavior[Command] =
+    // Behaviors.setup is a factory for creating behaviors.
         Behaviors.setup(new Trainer(_, traId))
     
     trait Command
@@ -20,6 +24,15 @@ object Trainer {
 }
 
 class Trainer(context: ActorContext[Trainer.Command], traId: TrainerIdentifier) extends AbstractBehavior[Trainer.Command](context) {
+    /** The behavior of the Trainer actor.
+      *
+      * The Trainer actor is in charge of training the model with the given data,
+      * and then sending the trained model to the Supervisor.
+      *
+      * @param context The actor context.
+      * @param traId The identifier of the Trainer actor.
+      * @return The behavior of the Trainer actor.
+      */
     import Trainer._
 
     // TODO
@@ -28,6 +41,10 @@ class Trainer(context: ActorContext[Trainer.Command], traId: TrainerIdentifier) 
     context.log.info("Trainer {} started", traId.toString())
 
     override def onMessage(msg: Command): Behavior[Command] =
+    /** The onMessage method is responsible for handling the messages that are sent to the Trainer actor.
+      * @param msg The message that is received.
+      *
+      */
         msg match {
             // TODO
             case _ =>
@@ -35,6 +52,10 @@ class Trainer(context: ActorContext[Trainer.Command], traId: TrainerIdentifier) 
         }
     
     override def onSignal: PartialFunction[Signal,Behavior[Command]] = {
+        /** The onSignal method is responsible for handling the signals that are sent to the Trainer actor.
+          * @param signal The signal that is received.
+          * @return The behavior of the Trainer actor.
+          */
         case PostStop =>
             context.log.info("Trainer {} stopped", traId.toString())
             this


### PR DESCRIPTION
## Description
This PR adds inline documentation to the scala_core/src/main/scala/org/nimbleedge/envisedge/Trainer.scala file.

## Relevant Issue


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/NimbleEdge/EnvisEdge/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/NimbleEdge/EnvisEdge/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [NimbleEdge Styleguide](https://numpydoc.readthedocs.io/en/latest/format.html)